### PR TITLE
sanitize: unify validation, remove base64 duplication

### DIFF
--- a/include/challenge_manager.h
+++ b/include/challenge_manager.h
@@ -91,7 +91,7 @@ union ChallengerStateUnion
 class ChallengeManager : public BanjaxFilter {
 protected:	
 	// AES key. 
-    AES_KEY enc_key, dec_key;
+  AES_KEY enc_key, dec_key;
 	// Number of zeros needed at the end of the SHA hash 
 	unsigned int number_of_trailing_zeros;
 	// string to replace the number of trailing zeros in the javascript
@@ -100,7 +100,7 @@ protected:
 	static std::string zeros_in_javascript;
 	
     std::vector<std::string> split(const std::string &, char);
-	bool check_sha(const char* cookiestr, const char* cookie_val_end);
+    bool check_sha(const char* cookiestr);
 	bool replace(std::string &original, std::string &from, std::string &to);
 
     //Hosts that challenger needs to check
@@ -161,14 +161,7 @@ protected:
    * @return        true if the cookie is valid
    */
 
-  bool check_cookie(std::string cookie_value, std::string client_ip);
-  /**
-   * Generates the token from the client ip and the cookie's validity
-   * @param  ip client ip
-   * @param  t  time until which the cookie will be valid
-   * @return    the encrypted token
-   */
-  std::string generate_token(std::string client_ip, long time);
+  bool check_cookie(std::string answer, std::string cookie_value, std::string client_ip, bool validate_sha);
   
   //TODO: This needs to be changed to adopt Otto's approach in placing
   //the variable info in cookie header and make the jscript to read them

--- a/src/ats_event_handler.cpp
+++ b/src/ats_event_handler.cpp
@@ -197,6 +197,11 @@ ATSEventHandler::handle_response(BanjaxContinuation* cd)
       cd->transaction_muncher.append_header(
           "Set-Cookie", (((FilterExtendedResponse*)cd->response_info.response_data))->set_cookie_header.c_str());
     }
+    if (buf.size() == 0) {
+      // When we get here, no valid response body was generated somehow.
+      // Insert one, to prevent triggering an assert in TSHttpTxnErrorBodySet
+      buf.append("Not authorized");
+    }
     char* b = (char*) TSmalloc(buf.size());
     memcpy(b, buf.data(), buf.size());
     TSHttpTxnErrorBodySet(cd->txnp, b, buf.size(),


### PR DESCRIPTION
Pull summary:
- Drops the base64 methods and use those in the base64 class. The used methods remain identical though, they where duplicates.
- Use the same cookie generator and validator for both captcha and computational challenges.
- Use the same cookie name for both challenge types. Make the computational challenge clear the cookie to prevent an infinite reload loop. This should allow switching the challenge method more seamlessly (without forcing revalidation for users who already passed a challenge)
- Fix an assert when no response body is generated by any intercepting filters (due to misconfiguration)
